### PR TITLE
fix strip function for ssh urls

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -138,5 +138,5 @@ function executeHook (appid, app, payload, cb) {
 }
 
 function strip (url) {
-    return url.replace(/(https?|git):\/\/github\.com\/|\.git/g, '')
+    return url.replace(/(https?:\/\/|git@)github\.com(\/|:)|\.git/g, '')
 }


### PR DESCRIPTION
previous behavior

``` js
strip('https://github.com/username/reponame')
// => username/reponame
strip('git@github.com:username/reponame')
// => git@github.com:/username/reponame
```

new behavior

``` js
strip('https://github.com/username/reponame')
// => username/reponame
strip('git@github.com:username/reponame')
// => username/reponame
```
