### PR TITLE
update pm2 so that it can be installed in node v0.11.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "yyx990803@gmail.com"
   },
   "dependencies": {
-    "pm2": "~0.7.7",
+    "pm2":"^0.10.8",
     "colors": "~0.6.0",
     "async": "~0.2.9",
     "mkdirp": "~0.3.5",


### PR DESCRIPTION
Hi,

just install the new node v0.11.13

Found that pod cannot be installed because of pm2 0.7 depends on old usage module.

So, I updated the pm2. 

And seems that pm2 need to be installed with

    sudo npm install --save pm2 --unsafe-perm

Not sure how to force the --unsafe-perm in package.json. Please help

