### PR TITLE
Fix #18: "Unexpected token u"

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -48,7 +48,7 @@ app.get('/json', auth, function (req, res) {
 
 app.post('/hooks/:appid', express.bodyParser(), function (req, res) {
     var appid = req.params.appid,
-        payload = req.body.payload,
+        payload = JSON.stringify(req.body),
         app = conf.apps[appid]
 
     try {


### PR DESCRIPTION
As per issue #18, I was getting this response when I pushed to a webhook-enabled repo:

![image](https://cloud.githubusercontent.com/assets/1486634/5499822/26346ece-8705-11e4-995d-dc573d04bf6d.png)

I implemented the fix @Viv-Rajkumar's suggested in the issue, and then got a successful response and process update/restart for subsequent pushes.