### PR TITLE
Fix for "Cannot find module 'debug'"

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "mkdirp": "^0.5.0",
     "cli-table": "^0.3.1",
     "express": "^3.4.4",
-    "ejs": "^2.3.1"
+    "ejs": "^2.3.1",
+    "debug": "^2.1.3"
   },
   "devDependencies": {
-    "debug": "^2.1.3",
     "jscoverage": "^0.5.9",
     "mocha": "^2.2.1",
     "request": "^2.54.0"


### PR DESCRIPTION
Moved the debug module out of devDependencies because it is required by lib/api.js.