### PR TITLE
compatibility with gitlab web hooks

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -94,7 +94,9 @@ function verify (req, app, payload) {
         return
     }
     // skip it with [pod skip] message
-    var commit = payload.head_commit
+    // use gitlab's payload structure if detected
+    var commit = payload.head_commit ? payload.head_commit : 
+        payload.commits[payload.commits.length - 1];
     console.log('commit message: ' + commit.message)
     if (/\[pod skip\]/.test(commit.message)) {
         console.log('aborted.')


### PR DESCRIPTION
```
pod remote my-repo git@my.gitlab.server:my-group/my-repo
pod web start
```

then go into my.gitlab.server, add deploy keys and enable web hooks for my-repo