### PR TITLE
Fixed typographical error, changed accomodate to accommodate in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ The API methods follow a conventional error-first callback style. Refer to the s
 ### 0.8.0
 
 - Upgrade pm2 to 0.12.9, which should make pod now work properly with Node 0.11/0.12 and latest stable iojs.
-- Fix web services to accomodate github webhook format change (#29)
+- Fix web services to accommodate github webhook format change (#29)
 - Now links the pm2 executable automatically when installed
 
 ### 0.7.4


### PR DESCRIPTION
yyx990803, I've corrected a typographical error in the documentation of the [pod](https://github.com/yyx990803/pod) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.