### PR TITLE
Improved Hook Repo Validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "pm2": "^0.12.9",
+    "parse-github-url": "^0.2.0",
     "colors": "^0.6.0",
     "async": "^0.9.0",
     "mkdirp": "^0.5.0",

--- a/web/app.js
+++ b/web/app.js
@@ -4,6 +4,7 @@ var http     = require('http'),
     spawn    = require('child_process').spawn,
     express  = require('express'),
     pod      = require('../lib/api'),
+    ghURL    = require('parse-github-url'),
     app      = express()
 
 // late def, wait until pod is ready
@@ -89,7 +90,7 @@ function verify (req, app, payload) {
     // check repo match
     var repo = payload.repository
     console.log('\nreceived webhook request from: ' + repo.url)
-    if (strip(repo.url) !== strip(app.remote)) {
+    if (ghURL(repo.url).repopath !== ghURL(app.remote).repopath) {
         console.log('aborted.')
         return
     }
@@ -149,8 +150,4 @@ function executeHook (appid, app, payload, cb) {
             })
         })
     })
-}
-
-function strip (url) {
-    return url.replace(/^(https?:\/\/|git@)github\.com(\/|:)|\.git$/g, '')
 }


### PR DESCRIPTION
After generating my SSH key and adding it to Github and `authorized_keys`, I attempted to configure my app with both:

```
pod remote <app> ssh://git@github.com/<author>/<repo>.git
```

and

```
pod remote <app> https://<user>:<token>@github.com/<author>/<repo>.git
```

In both cases, the repo was cloned, and I was able to start the app, but received an "aborted" message every time the webhook was triggered. The problem was the RegEx used to compare the remote in the payload to the remote in the app config. Here is a fix.