### PR TITLE
Resolved issue with input being blocked

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -37,11 +37,15 @@ var cli = {
 
     create: function (appname) {
         if (!appname) exit()
+
+        rl.close()
         api.createApp(appname, output)
     },
 
     remote: function (appname, repo, branch) {
         if (!appname || !repo) exit()
+
+        rl.close()
         api.createApp(appname, {
             remote: repo,
             branch: branch
@@ -59,10 +63,12 @@ var cli = {
         }
         if (!appname) exit()
         if (force) {
+            rl.close()
             return api.removeApp(appname, output)
         }
         rl.question('really delete ' + appname.yellow + '? (y/N)', function (reply) {
             if (reply.toLowerCase() === 'y') {
+                rl.close()
                 api.removeApp(appname, output)
             } else {
                 log('aborted.')


### PR DESCRIPTION
Resolved issue with input being block when running an `exec` command when needing to input username/password.

The primary issue resolved is when a username and password are required for a remote repository. `readline` captures stdin and doesn't permit any other processes to read from stdin.

To resolve this, I've closed the `readline` instance before calling the affected api methods.

While this (currently) only effects the `git clone` calls, I also added `rl.close()` statements to the `rm` call just in case `rm -rf` requires some input (unlikely) in the future.

Fixes issues #32 and #47.