### PR TITLE
Added support for PM2 "script" key/value in app config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Example Config:
             // guarunteed to be correct.
             "port": 8080,
 
-            // pod will use this script before checking
+            // pod will look for this script before checking
             // in package.json of the app.
             "script": "dist/server.js",
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Example Config:
     "node_env": "development",
 
     // this can be overwritten in each app's package.json's "main" field
+    // or in the app's configuration below using the "script" field
     "default_script": "app.js",
 
     // minimum uptime to be considered stable,
@@ -185,6 +186,10 @@ Example Config:
             // main file (for displaying only), but not
             // guarunteed to be correct.
             "port": 8080,
+
+            // pod will use this script if one is not set
+            // in package.json of the app.
+            "script": "dist/server.js",
 
             // *** any valid pm2 config here gets passed to pm2. ***
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Example Config:
             // guarunteed to be correct.
             "port": 8080,
 
-            // pod will use this script if one is not set
+            // pod will use this script before checking
             // in package.json of the app.
             "script": "dist/server.js",
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -90,7 +90,7 @@ api.createApp = function (appname, options, callback) {
 }
 
 api.removeApp = function (appname, callback) {
-    
+
     if (appname === webInterfaceId) {
         return abort(ERRORS.WEB, callback)
     }
@@ -355,7 +355,7 @@ api.getAppInfo = function (appname) {
     var info = getAppPaths(appname)
     info.config = globalConfig.apps[appname]
     if (!info.config) return
-    info.script = path.resolve(info.workPath, getAppMainScript(info.workPath) || globalConfig.default_script)
+    info.script = path.resolve(info.workPath, getAppMainScript(info.workPath, appname) || globalConfig.default_script)
     info.port = info.config.port || sniffPort(info.script) || null
     return info
 }
@@ -467,10 +467,17 @@ function findInList (appname, list) {
     return ret.length > 0 ? ret : null
 }
 
-function getAppMainScript (workPath) {
+function getAppMainScript (workPath, appname) {
     var pkg = readJSON(workPath + '/package.json')
+    var main
+
     if (pkg && pkg.main) {
-        var main = pkg.main
+        main = pkg.main
+    } else if (globalConfig.apps[appname].script) {
+        main = globalConfig.apps[appname].script
+    }
+
+    if (main) {
         if (/\.js$/.test(main)) {
             return main
         } else {

--- a/lib/api.js
+++ b/lib/api.js
@@ -471,10 +471,10 @@ function getAppMainScript (workPath, appname) {
     var pkg = readJSON(workPath + '/package.json')
     var main
 
-    if (pkg && pkg.main) {
-        main = pkg.main
-    } else if (globalConfig.apps[appname].script) {
+    if (globalConfig.apps[appname].script) {
         main = globalConfig.apps[appname].script
+    } else if (pkg && pkg.main) {
+        main = pkg.main
     }
 
     if (main) {


### PR DESCRIPTION
This commit adds support for the "script" key/value in a pod app's config. See [here](http://pm2.keymetrics.io/docs/usage/pm2-doc-single-page/#options) for PM2 documentation.

This behavior is beneficial if there is no default entry point defined in the package.json.

Possible use cases:
- Unable to modify the repository (unlikely, but possible.)
- Repository with two different codebases included (also unlikely but certainly possible.)

@yyx990803 Before merging, should the `script` key/value take precedence over package.json's `main` key/value?