### PR TITLE
Added support for Bitbucket webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ You can also set up a remote app to track an arbitrary git address. However in t
 
 Starting in 0.8.2, GitLab webhooks are also supported.
 
+Starting in 0.8.6, Bitbucket webhooks are also supported.
+
 ## Configuration
 
 The config file lives at `~/.podrc`. Note since 0.7.0 all fields follow the underscore format so check your config file if things break after upgrading.
@@ -264,6 +266,12 @@ pod.once('ready', function () {
 The API methods follow a conventional error-first callback style. Refer to the source for more details.
 
 ## Changelog
+
+### 0.8.6
+
+- Added support for Bitbucket webhooks.
+- Added ability to specify entry point in app's config in `.podrc` by using the `script` field.
+- Fixed issue with the `readline` module blocking stdin. This caused issues when attempting to clone a repository that required a username/password.
 
 ### 0.8.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pod",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "preferGlobal": "true",
   "author": {
     "name": "Evan You",

--- a/web/app.js
+++ b/web/app.js
@@ -89,10 +89,10 @@ function verify (req, app, payload) {
     if (!app.remote) return
     // check repo match
 
-    console.log(JSON.stringify(payload))
+    payload.repository.links.html.href
     var repo = payload.repository
 
-    if (/bitbucket\.org/.test(payload.canon_url)) {
+    if (/bitbucket\.org/.test(repo.links.html.href)) {
         console.log('\nreceived webhook request from: ' + payload.canon_url + repo.absolute_url)
     } else {
         console.log('\nreceived webhook request from: ' + repo.url)

--- a/web/app.js
+++ b/web/app.js
@@ -89,7 +89,7 @@ function verify (req, app, payload) {
     if (!app.remote) return
     // check repo match
 
-    console.log(payload)
+    console.log(JSON.stringify(payload))
     var repo = payload.repository
 
     if (/bitbucket\.org/.test(payload.canon_url)) {

--- a/web/app.js
+++ b/web/app.js
@@ -88,6 +88,8 @@ function verify (req, app, payload) {
     // not even a remote app
     if (!app.remote) return
     // check repo match
+
+    console.log(payload)
     var repo = payload.repository
 
     if (/bitbucket\.org/.test(payload.canon_url)) {

--- a/web/app.js
+++ b/web/app.js
@@ -96,7 +96,7 @@ function verify (req, app, payload) {
     }
     // skip it with [pod skip] message
     // use gitlab's payload structure if detected
-    var commit = payload.head_commit ? payload.head_commit : 
+    var commit = payload.head_commit ? payload.head_commit :
         payload.commits[payload.commits.length - 1];
     console.log('commit message: ' + commit.message)
     if (/\[pod skip\]/.test(commit.message)) {
@@ -104,7 +104,10 @@ function verify (req, app, payload) {
         return
     }
     // check branch match
-    var branch = payload.ref.replace('refs/heads/', ''),
+    // support bitbucket webhooks payload structure
+    var ref = commit.branch ? commit.branch : payload.ref
+
+    var branch = ref.replace('refs/heads/', ''),
         expected = app.branch || 'master'
     console.log('expected branch: ' + expected + ', got branch: ' + branch)
     if (branch !== expected) {

--- a/web/app.js
+++ b/web/app.js
@@ -89,11 +89,20 @@ function verify (req, app, payload) {
     if (!app.remote) return
     // check repo match
     var repo = payload.repository
-    console.log('\nreceived webhook request from: ' + repo.url)
-    if (ghURL(repo.url).repopath !== ghURL(app.remote).repopath) {
+
+    if (/bitbucket\.org/.test(payload.canon_url)) {
+        console.log('\nreceived webhook request from: ' + payload.canon_url + repo.absolute_url)
+    } else {
+        console.log('\nreceived webhook request from: ' + repo.url)
+    }
+
+    var repoURL = repo.absolute_url ? repo.absolute_url : repo.url
+
+    if (ghURL(repoURL).repopath !== ghURL(app.remote).repopath) {
         console.log('aborted.')
         return
     }
+
     // skip it with [pod skip] message
     // use gitlab's payload structure if detected
     var commit = payload.head_commit ? payload.head_commit :

--- a/web/app.js
+++ b/web/app.js
@@ -90,16 +90,19 @@ function verify (req, app, payload) {
     // check repo match
 
     var repo = payload.repository
+    var repoURL
 
-    // console.error(repo.links.html.href)
-
-    if (/bitbucket\.org/.test(repo.links.html.href)) {
+    if (repo.links && /bitbucket\.org/.test(repo.links.html.href)) {
         console.log('\nreceived webhook request from: ' + repo.links.html.href)
+
+        repoURL = repo.links.html.href
     } else {
         console.log('\nreceived webhook request from: ' + repo.url)
+
+        repoURL = repo.url
     }
 
-    var repoURL = repo.links.html.href ? repo.links.html.href : repo.url
+    if (!repoURL) return
 
     if (ghURL(repoURL).repopath !== ghURL(app.remote).repopath) {
         console.log('aborted.')
@@ -119,6 +122,8 @@ function verify (req, app, payload) {
             payload.commits[payload.commits.length - 1];
     }
 
+    if (!commit) return
+
     // skip it with [pod skip] message
     console.log('commit message: ' + commit.message)
     if (/\[pod skip\]/.test(commit.message)) {
@@ -127,6 +132,8 @@ function verify (req, app, payload) {
     }
     // check branch match
     var ref = commit.name ? commit.name : payload.ref
+
+    if (!ref) return
 
     var branch = ref.replace('refs/heads/', ''),
         expected = app.branch || 'master'


### PR DESCRIPTION
This PR adds support for Bitbucket webhooks when watching a remote repository.

The webhook structure for Bitbucket is drastically different from that of Github/Gitlab.

I also updated the README to reflect these changes.

Added changelog entry for version `0.8.6`, and bumped version to `0.8.6` in `package.json`.