### PR TITLE
Added support for Github `ping` events

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -58,6 +58,14 @@ app.post('/hooks/:appid', express.bodyParser(), function (req, res) {
         return res.end(e.toString())
     }
 
+    if (req.get('X-GitHub-Event') === 'ping') {
+        if (ghURL(payload.repository.url).repopath === ghURL(app.remote).repopath) {
+            return res.status(200).end()
+        } else {
+            return res.status(500).end()
+        }
+    }
+
     if (app && verify(req, app, payload)) {
         executeHook(appid, app, payload, function () {
             res.end()


### PR DESCRIPTION
This commit adds support for responding correctly to Github `ping` events. (Header: `X-Github-Event: ping`)

This does not handle any other services (Bitbucket, Gitlab) as they do not send a ping request (to my knowledge, after looking through their respective documentation.)

I have also added tests for this behavior.

This hotfix should resolve #55 

/cc @kylemcdonald