### PR TITLE
Add Global Environment Variable Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,13 @@ Example Config:
             "remote": "yyx990803/my-remote-app", // github shorthand
             "branch": "test" // if not specified, defaults to master
         }
-    }
+    },
+    
+    // pass environment variables to all apps
+    "env": {
+        "SERVER_NAME": "Commodore",
+        "CERT_DIR": "/path/to/certs"
+    }  
 }
 ```
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -568,6 +568,10 @@ function prepareConfig (appInfo) {
         }
     }
 
+    for (o in globalConfig.env) {
+        conf.env[o] = globalConfig.env[o]
+    }
+
     // constraints, fallback to global config
     conf.min_uptime   = conf.min_uptime || globalConfig.min_uptime || undefined
     conf.max_restarts = conf.max_restarts || globalConfig.max_restarts || undefined


### PR DESCRIPTION
Supply environment variables to all apps via the `~/.podrc` `env` property.